### PR TITLE
RE: #723 - correcting syntax error

### DIFF
--- a/actions/cola.vbs
+++ b/actions/cola.vbs
@@ -46,7 +46,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-CALL changelog_update("01/20/2017", "Worker signature should now auto-populate.", "Kelly Hiestand, Wright County."
+CALL changelog_update("01/20/2017", "Worker signature should now auto-populate.", "Kelly Hiestand, Wright County.")
 call changelog_update("11/13/2016", "Initial version.", "Veronica Cary, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
@@ -119,7 +119,7 @@ transmit
 
 'non standard arrears payment ordered
 	ARREARSresult = msgbox ("Is there a non-standard arrears payment ordered (not 20%)?" & VbNewline & VbNewline & _
-		"If YES make sure non-accrual is on NCOD and case is coded with 20% overide on SUOD.", VbOKCancel)
+		"If YES make sure non-accrual is on NCOD and case is coded with 20% override on SUOD.", VbOKCancel)
 	If ARREARSresult = vbCancel then
 		MsgBox "Case may not be appropriate for COLA. Please review case further before continuing. Script Ended."
 		StopScript


### PR DESCRIPTION
BLIP: This update corrects a syntax that is preventing the script from running. I have also corrected a spelling error on the word override (see line 122).