### PR TITLE
See #419

### DIFF
--- a/actions/refer-to-mod.vbs
+++ b/actions/refer-to-mod.vbs
@@ -1,10 +1,4 @@
 
-'LOADING GLOBAL VARIABLES--------------------------------------------------------------------
-Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")
-Set fso_command = run_another_script_fso.OpenTextFile("Q:\Blue Zone Scripts\Child Support\locally-installed-files\~globvar.vbs")
-text_from_the_other_script = fso_command.ReadAll
-fso_command.Close
-Execute text_from_the_other_script
 
 'GATHERING STATS----------------------------------------------------------------------------------------------------
 name_of_script = "refer-to-mod.vbs"

--- a/actions/refer-to-mod.vbs
+++ b/actions/refer-to-mod.vbs
@@ -1,5 +1,4 @@
 
-
 'GATHERING STATS----------------------------------------------------------------------------------------------------
 name_of_script = "refer-to-mod.vbs"
 start_time = timer
@@ -42,7 +41,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-call changelog_update("08/15/2017", "Created edit boxes for mod worker info for collaborative version of the script.", "Wendy LeVesseur, Anoka County")
+call changelog_update("08/17/2017", "Created edit boxes for mod worker info for collaborative version of the script and fixed bugs.", "Wendy LeVesseur, Anoka County")
 call changelog_update("03/10/2017", "Initial version.", "Wendy LeVesseur, Anoka County")
 
 
@@ -849,6 +848,7 @@ IF update_mod_worker = checked THEN
 						EMWriteScreen mod_worker_title_txt, 16, 15
 						transmit
 						EMWriteScreen mod_worker_phone_txt, 16, 15
+						transmit
 				END IF
 
 			
@@ -900,7 +900,8 @@ If CAWD_check = checked then
 	PF5
 	EMWriteScreen "FREE", 4, 37
 	EMWriteScreen "*** Special Services assessment received from the parties?", 10, 4
-	EMWriteScreen dateadd("d", date, 7), 17, 21
+	worklist_date= dateadd("d", date, 7)
+	CALL write_date(worklist_date, "MM/DD/YYYY", 17, 21)
 	transmit
 End if
 


### PR DESCRIPTION
This update makes this script usable for the rest of the Collaborative (by offering counties except Anoka the user the option to type in mod worker name, title and phone to update mod worker info).  The script checks the cali code to identify Anoka users, and for Anoka users, displays a dropdown for mod workers instead of the text fields.   Again, this script does not do all that was initially requested to do.  However, it is a great first step that can be enhanced in the future.

Anoka County recently had a telecommunications upgrade that changed all of our phone numbers, and this fix also updates Anoka County mod worker phone numbers.